### PR TITLE
refactor(*): use ttl indexes

### DIFF
--- a/src/auth/models/refresh-token.ts
+++ b/src/auth/models/refresh-token.ts
@@ -6,7 +6,7 @@ export class RefreshToken {
   @Prop({ required: true, index: true })
   value!: string;
 
-  @Prop({ default: () => new Date() })
+  @Prop({ default: () => new Date(), expires: '1w' })
   public createdAt?: Date;
 }
 

--- a/src/auth/services/auth.service.spec.ts
+++ b/src/auth/services/auth.service.spec.ts
@@ -64,8 +64,6 @@ describe('AuthService', () => {
     authKeys = module.get('AUTH_TOKEN_KEY');
     refreshKeys = module.get('REFRESH_TOKEN_KEY');
     connection = module.get(getConnectionToken());
-
-    await service.onModuleInit();
   });
 
   afterEach(async () => {
@@ -253,26 +251,6 @@ describe('AuthService', () => {
       expect(service.verifyToken(JwtTokenPurpose.context, token).id).toEqual(
         'FAKE_USER_ID',
       );
-    });
-  });
-
-  describe('#removeOldRefreshTokens()', () => {
-    it('should remove old tokens', async () => {
-      const key = refreshKeys.privateKey.export({
-        format: 'pem',
-        type: 'pkcs8',
-      });
-      const token = sign({ id: 'FAKE_USER_ID' }, key, {
-        algorithm: 'ES512',
-        expiresIn: '7d',
-      });
-
-      const createdAt = new Date();
-      createdAt.setDate(createdAt.getDate() - 8);
-      await refreshTokenModel.create({ value: token, createdAt });
-
-      await service.removeOldRefreshTokens();
-      expect(await refreshTokenModel.findOne({ value: token })).toBeNull();
     });
   });
 });

--- a/src/auth/services/auth.service.ts
+++ b/src/auth/services/auth.service.ts
@@ -1,4 +1,4 @@
-import { Inject, Injectable, Logger, OnModuleInit } from '@nestjs/common';
+import { Inject, Injectable } from '@nestjs/common';
 import { sign, verify } from 'jsonwebtoken';
 import { RefreshToken, RefreshTokenDocument } from '../models/refresh-token';
 import { InvalidTokenError } from '../errors/invalid-token.error';

--- a/src/auth/services/auth.service.ts
+++ b/src/auth/services/auth.service.ts
@@ -8,9 +8,7 @@ import { InjectModel } from '@nestjs/mongoose';
 import { Error, Model } from 'mongoose';
 
 @Injectable()
-export class AuthService implements OnModuleInit {
-  private logger = new Logger(AuthService.name);
-
+export class AuthService {
   constructor(
     @InjectModel(RefreshToken.name)
     private refreshTokenModel: Model<RefreshTokenDocument>,


### PR DESCRIPTION
This PR removes the cron schedule and leaves the refresh token clear interval to the MongoDB TTL Indexer. 

View more here: https://docs.mongodb.com/manual/core/index-ttl/

NEEDS TESTING BEFORE MERGE